### PR TITLE
Add Message when invalid recovery phrase

### DIFF
--- a/lib/screen/account/import_account_page.dart
+++ b/lib/screen/account/import_account_page.dart
@@ -19,6 +19,7 @@ import 'package:autonomy_flutter/util/wallet_storage_ext.dart';
 import 'package:autonomy_flutter/view/au_filled_button.dart';
 import 'package:autonomy_flutter/view/au_text_field.dart';
 import 'package:autonomy_flutter/view/back_appbar.dart';
+import 'package:autonomy_flutter/view/responsive.dart';
 import 'package:autonomy_theme/autonomy_theme.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/gestures.dart';
@@ -26,7 +27,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:nft_collection/services/tokens_service.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
-import 'package:autonomy_flutter/view/responsive.dart';
 
 class ImportAccountPage extends StatefulWidget {
   const ImportAccountPage({Key? key}) : super(key: key);
@@ -146,10 +146,23 @@ class _ImportAccountPageState extends State<ImportAccountPage> {
                               setState(() {
                                 _isSubmissionEnabled =
                                     numberOfWords == 12 || numberOfWords == 24;
+                                isError = false;
                               });
                             },
                           ),
                         ],
+                      ),
+                    ),
+                    const SizedBox(
+                      height: 8,
+                    ),
+                    Visibility(
+                      visible: isError,
+                      child: Text(
+                        'invalid_recovery_phrase'.tr(),
+                        style: theme.textTheme.atlasBlackNormal12.copyWith(
+                          color: AppColor.red,
+                        ),
                       ),
                     ),
                     const SizedBox(),

--- a/lib/screen/settings/connection/accounts_view.dart
+++ b/lib/screen/settings/connection/accounts_view.dart
@@ -14,7 +14,6 @@ import 'package:autonomy_flutter/service/configuration_service.dart';
 import 'package:autonomy_flutter/util/constants.dart';
 import 'package:autonomy_flutter/util/string_ext.dart';
 import 'package:autonomy_flutter/util/style.dart';
-
 import 'package:autonomy_flutter/view/account_view.dart';
 import 'package:autonomy_flutter/view/au_button_clipper.dart';
 import 'package:autonomy_flutter/view/au_filled_button.dart';
@@ -292,7 +291,7 @@ class _AccountsViewState extends State<AccountsView> {
                           child: AuFilledButton(
                             text: (account.persona != null)
                                 ? "delete".tr()
-                                : "remove".tr(),
+                                : "remove".tr().toUpperCase(),
                             onPress: () {
                               Navigator.of(context).pop();
                               _deleteAccount(pageContext, account);

--- a/lib/view/au_text_field.dart
+++ b/lib/view/au_text_field.dart
@@ -110,7 +110,8 @@ class AuTextField extends StatelessWidget {
               : theme.textTheme.atlasSpanishGreyNormal20,
         ),
         keyboardType: keyboardType,
-        style: theme.textTheme.subtitle1,
+        style: theme.textTheme.subtitle1
+            ?.copyWith(color: isError ? AppColor.red : null),
         controller: controller,
         onChanged: onChanged,
         onSubmitted: onSubmit ?? onChanged,


### PR DESCRIPTION
Add Message when user entered invalid recovery phrase
- Story link: [[Enhancement] Missing validation message for invalid recovery phrase when user imports the seeds#2009](https://github.com/bitmark-inc/autonomy-apps/issues/2009)

**Describe your changes**


