### PR TITLE
Fix when user click notification

### DIFF
--- a/lib/screen/home/home_navigation_page.dart
+++ b/lib/screen/home/home_navigation_page.dart
@@ -286,7 +286,7 @@ class _HomeNavigationPageState extends State<HomeNavigationPage> {
         Navigator.of(context).popUntil((route) =>
             route.settings.name == AppRouter.homePage ||
             route.settings.name == AppRouter.homePageNoTransition);
-        _pageController.jumpToPage(1);
+        _onItemTapped(1);
         break;
       default:
         log.warning("unhandled notification type: $notificationType");


### PR DESCRIPTION
Fix when user click notification, then go to discovery page with wrong home navigation and unhide number of unread discovery
- Story link: [https://github.com/bitmark-inc/autonomy/issues/<number>
](https://github.com/bitmark-inc/au-support-board/issues/1004)
**Describe your changes**
- [ ] Use onItemTapped() instead of jumpToPage()
