### PR TITLE
Fix Proceed and Send Button Position

### DIFF
--- a/lib/screen/migration/key_sync_page.dart
+++ b/lib/screen/migration/key_sync_page.dart
@@ -11,10 +11,10 @@ import 'package:autonomy_flutter/screen/migration/key_sync_state.dart';
 import 'package:autonomy_flutter/view/au_filled_button.dart';
 import 'package:autonomy_flutter/view/back_appbar.dart';
 import 'package:autonomy_flutter/view/responsive.dart';
+import 'package:autonomy_theme/autonomy_theme.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:autonomy_theme/autonomy_theme.dart';
 
 class KeySyncPage extends StatelessWidget {
   const KeySyncPage({Key? key}) : super(key: key);
@@ -40,7 +40,7 @@ class KeySyncPage extends StatelessWidget {
             },
           ),
           body: Container(
-            margin: ResponsiveLayout.pageEdgeInsets,
+            margin: ResponsiveLayout.pageEdgeInsetsWithSubmitButton,
             child: Column(
               children: [
                 Expanded(

--- a/lib/screen/settings/crypto/send_review_page.dart
+++ b/lib/screen/settings/crypto/send_review_page.dart
@@ -21,6 +21,7 @@ import 'package:autonomy_flutter/util/wallet_storage_ext.dart';
 import 'package:autonomy_flutter/util/xtz_utils.dart';
 import 'package:autonomy_flutter/view/au_filled_button.dart';
 import 'package:autonomy_flutter/view/back_appbar.dart';
+import 'package:autonomy_flutter/view/responsive.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -168,11 +169,7 @@ class _SendReviewPageState extends State<SendReviewPage> {
       body: Stack(
         children: [
           Container(
-            margin: EdgeInsets.only(
-                top: 16.0,
-                left: 16.0,
-                right: 16.0,
-                bottom: MediaQuery.of(context).padding.bottom),
+            margin: ResponsiveLayout.pageEdgeInsetsWithSubmitButton,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [


### PR DESCRIPTION
**Fix Button Position**

- Story link: [Proceed button in "Conflict detect" screen displays too low. It should move to higher as design #2122](https://github.com/bitmark-inc/autonomy-apps/issues/2122)

**Describe your changes**

- [x] Fix Proceed Button Position
- [x] Fix Send Button Position
