### PR TITLE
Fix Close icon size

### DIFF
--- a/lib/screen/detail/preview/artwork_preview_page.dart
+++ b/lib/screen/detail/preview/artwork_preview_page.dart
@@ -584,7 +584,7 @@ class _ArtworkPreviewPageState extends State<ArtworkPreviewPage>
                       children: [
                         Text(
                           assetToken?.title ?? '',
-                          style: theme.textTheme.ppMori400White12,
+                          style: theme.textTheme.ppMori400White14,
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                         ),
@@ -617,9 +617,14 @@ class _ArtworkPreviewPageState extends State<ArtworkPreviewPage>
                   actions: [
                     IconButton(
                       onPressed: () => Navigator.pop(context),
+                      constraints: const BoxConstraints(
+                        maxWidth: 44,
+                        maxHeight: 44,
+                      ),
                       icon: Icon(
                         AuIcon.close,
                         color: theme.colorScheme.secondary,
+                        size: 20,
                       ),
                       tooltip: 'close_icon',
                     )


### PR DESCRIPTION
**Description**

- Story link: [X button of Artwork preview page is larger than X button of Artwork infor page](https://github.com/bitmark-inc/autonomy-apps/issues/2149)

**Describe your changes**

- [x] Fix close icon size
- [x] Update title size in artwork preview
