### PR TITLE
Replace thumbnail by artwork

### DIFF
--- a/lib/screen/feed/feed_artwork_details_page.dart
+++ b/lib/screen/feed/feed_artwork_details_page.dart
@@ -99,7 +99,7 @@ class _FeedArtworkDetailsPageState extends State<FeedArtworkDetailsPage> {
           children: [
             Text(
               token!.title,
-              style: theme.textTheme.ppMori400White12,
+              style: theme.textTheme.ppMori400White14,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
             ),
@@ -132,9 +132,14 @@ class _FeedArtworkDetailsPageState extends State<FeedArtworkDetailsPage> {
         actions: [
           IconButton(
             onPressed: () => Navigator.pop(context),
+            constraints: const BoxConstraints(
+              maxWidth: 44,
+              maxHeight: 44,
+            ),
             icon: Icon(
               AuIcon.close,
               color: theme.colorScheme.secondary,
+              size: 20,
             ),
             tooltip: 'close_icon',
           )
@@ -152,9 +157,10 @@ class _FeedArtworkDetailsPageState extends State<FeedArtworkDetailsPage> {
                   height: 40,
                 ),
                 GestureDetector(
-                  child: TokenThumbnailWidget(
-                    token: token!,
-                  ),
+                  child: Center(
+                      child: FeedArtwork(
+                    assetToken: token,
+                  )),
                   onTap: () => Navigator.of(context).pop(),
                 ),
                 const SizedBox(


### PR DESCRIPTION
**Description**

- Story link: 

1. [Gif artwork is autoplay in Discover mode but cannot play in Artwork infor page](https://github.com/bitmark-inc/autonomy-apps/issues/2148)
2. [X button of Artwork preview page is larger than X button of Artwork infor page](https://github.com/bitmark-inc/autonomy-apps/issues/2149)

**Describe your changes**

- [x] Replace thumbnail by artwork
- [x] Fix close Icon size and update title size