### PR TITLE
Fix Discovery: Disable Tap on preview

### DIFF
--- a/lib/screen/feed/feed_preview_page.dart
+++ b/lib/screen/feed/feed_preview_page.dart
@@ -165,8 +165,10 @@ class _FeedPreviewScreenState extends State<FeedPreviewScreen>
       },
       child: Column(children: [
         Center(
-          child: FeedArtwork(
-            assetToken: asset,
+          child: IgnorePointer(
+            child: FeedArtwork(
+              assetToken: asset,
+            ),
           ),
         ),
         const SizedBox(


### PR DESCRIPTION
**Description**

- Story link: https://github.com/bitmark-inc/autonomy/issues/<number>

**Describe your changes**

- [x] Disable Tab Action for artwork preview in discovery