### PR TITLE
fix user identity pop-up

### DIFF
--- a/lib/util/ui_helper.dart
+++ b/lib/util/ui_helper.dart
@@ -852,37 +852,41 @@ class UIHelper {
             child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            Text('alias'.tr(), style: theme.primaryTextTheme.headlineSmall),
-            const SizedBox(height: 16),
-            Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
+            Row(crossAxisAlignment: CrossAxisAlignment.start, children: [
               Expanded(
-                  child: Text(
-                name,
-                style: theme.primaryTextTheme.headlineMedium,
-                overflow: TextOverflow.ellipsis,
+                  child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (name.isNotEmpty) ...[
+                    Text(
+                      name,
+                      style: theme.textTheme.ppMori700White14,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 16),
+                  ],
+                  Text(
+                    address,
+                    style: theme.textTheme.ppMori400White14,
+                  ),
+                ],
               )),
-              GestureDetector(
-                child: Text("share".tr(),
-                    style: theme.primaryTextTheme.headlineMedium),
-                onTap: () => Share.share(address),
-              )
+              const SizedBox(width: 24),
+              IconButton(
+                  padding: EdgeInsets.zero,
+                  constraints: BoxConstraints(),
+                  onPressed: () => Share.share(address),
+                  icon: SvgPicture.asset(
+                    'assets/images/Share.svg',
+                    color: AppColor.white,
+                  )),
             ]),
-            const SizedBox(height: 16),
-            Text(
-              address,
-              style: ResponsiveLayout.isMobile
-                  ? theme.textTheme.ibmWhiteNormal14
-                  : theme.textTheme.ibmWhiteNormal16,
-            ),
-            const SizedBox(height: 56),
-            TextButton(
-              onPressed: () {
+            const SizedBox(height: 40),
+            OutlineButton(
+              onTap: () {
                 Navigator.of(context).pop();
               },
-              child: Text(
-                "close".tr(),
-                style: theme.primaryTextTheme.labelLarge,
-              ),
+              text: "close".tr(),
             ),
             const SizedBox(height: 15),
           ],

--- a/lib/util/ui_helper.dart
+++ b/lib/util/ui_helper.dart
@@ -874,7 +874,7 @@ class UIHelper {
               const SizedBox(width: 24),
               IconButton(
                   padding: EdgeInsets.zero,
-                  constraints: BoxConstraints(),
+                  constraints: const BoxConstraints(),
                   onPressed: () => Share.share(address),
                   icon: SvgPicture.asset(
                     'assets/images/Share.svg',


### PR DESCRIPTION
**Description**

- Story link: [Missing rebranding for User identity popup when clicking on user's address in provenance data in Artwork info page](https://github.com/bitmark-inc/autonomy-apps/issues/2520)

**Describe your changes**

- [x] Rebranding user identity pop-up
