### PR TITLE
Sang/28/fix/editorial header

### DIFF
--- a/lib/screen/editorial/article/article_detail.dart
+++ b/lib/screen/editorial/article/article_detail.dart
@@ -253,8 +253,9 @@ class _ArticleDetailPageState extends State<ArticleDetailPage> {
               ],
             ),
           ),
-          const SizedBox(width: 50.0),
           IconButton(
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
             onPressed: () async {
               await showModalBottomSheet<dynamic>(
                 context: context,

--- a/lib/screen/scan_qr/scan_qr_page.dart
+++ b/lib/screen/scan_qr/scan_qr_page.dart
@@ -241,7 +241,7 @@ class _ScanQRPageState extends State<ScanQRPage>
                                           const Duration(milliseconds: 300));
                                   setState(() {});
                                 },
-                                text: 'show_my_code'.tr(),
+                                text: 'scan_code'.tr(),
                                 color: _tabController.index == 0
                                     ? theme.colorScheme.primary
                                     : theme.auLightGrey,
@@ -260,7 +260,7 @@ class _ScanQRPageState extends State<ScanQRPage>
                                           const Duration(milliseconds: 300));
                                   setState(() {});
                                 },
-                                text: 'scan_code'.tr(),
+                                text: 'show_my_code'.tr(),
                                 color: _tabController.index == 1
                                     ? theme.colorScheme.primary
                                     : theme.auLightGrey,


### PR DESCRIPTION
**Description**

- Story link: 
- [Editorial header is cut off in iPhone 13](https://github.com/bitmark-inc/autonomy-apps/issues/2636)
- [The text in Scan QR code screen display incorrect](https://github.com/bitmark-inc/autonomy-apps/issues/2634)

**Describe your changes**

- [ ] Added a function A to process data B
- [ ] Created new column C to store D state
- [ ] Refactor workflow E to improve performance because of F
