### PR TITLE
Fix: wrong page when click on feed notif

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -219,6 +219,12 @@ enum HomePageTab {
   EDITORIAL,
 }
 
+enum HomeNavigatorTab {
+  DISCOVER,
+  COLLECTION,
+  WALLET,
+}
+
 @pragma('vm:entry-point')
 void downloadCallback(String id, DownloadTaskStatus status, int progress) {
   final SendPort? send =

--- a/lib/screen/home/home_navigation_page.dart
+++ b/lib/screen/home/home_navigation_page.dart
@@ -170,9 +170,9 @@ class _HomeNavigationPageState extends State<HomeNavigationPage>
     injector<CustomerSupportService>().getIssuesAndAnnouncement();
     super.initState();
     if (memoryValues.homePageInitialTab != HomePageTab.DISCOVER) {
-      _selectedIndex = 1;
+      _selectedIndex = HomeNavigatorTab.COLLECTION.index;
     } else {
-      _selectedIndex = 0;
+      _selectedIndex = HomeNavigatorTab.DISCOVER.index;
     }
     _pageController = PageController(initialPage: _selectedIndex);
 
@@ -446,7 +446,7 @@ class _HomeNavigationPageState extends State<HomeNavigationPage>
         Navigator.of(context).popUntil((route) =>
             route.settings.name == AppRouter.homePage ||
             route.settings.name == AppRouter.homePageNoTransition);
-        _pageController.jumpToPage(1);
+        _pageController.jumpToPage(HomeNavigatorTab.COLLECTION.index);
         break;
 
       case "customer_support_new_message":
@@ -476,7 +476,8 @@ class _HomeNavigationPageState extends State<HomeNavigationPage>
         Navigator.of(context).popUntil((route) =>
             route.settings.name == AppRouter.homePage ||
             route.settings.name == AppRouter.homePageNoTransition);
-        _pageController.jumpToPage(1);
+        memoryValues.homePageInitialTab = HomePageTab.DISCOVER;
+        _pageController.jumpToPage(HomeNavigatorTab.DISCOVER.index);
         final metricClient = injector<MetricClientService>();
         metricClient.addEvent(MixpanelEvent.tabNotification, data: {
           'type': notificationType,


### PR DESCRIPTION
**Description**

- Story link: [Collection page instead of Discover page displays when clicking on a push notification about new feed NFT#2655](https://github.com/bitmark-inc/autonomy-apps/issues/2655)

**Describe your changes**

- [ ] Added a function A to process data B
- [ ] Created new column C to store D state
- [ ] Refactor workflow E to improve performance because of F
