### PR TITLE
[ios] try to upgrade the deeplink scheme registration

### DIFF
--- a/ios/Runner-Inhouse-Info.plist
+++ b/ios/Runner-Inhouse-Info.plist
@@ -30,32 +30,14 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLName</key>
-			<string>autonomy-deeplink</string>
+			<string>me.autonomy</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
+				<string>wc</string>
 				<string>autonomy</string>
-			</array>
-		</dict>
-		<dict>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-			<key>CFBundleURLName</key>
-			<string>autonomy-tezos</string>
-			<key>CFBundleURLSchemes</key>
-			<array>
 				<string>autonomy-tezos</string>
 				<string>tezos</string>
-			</array>
-		</dict>
-		<dict>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-			<key>CFBundleURLName</key>
-			<string>autonomy-wc</string>
-			<key>CFBundleURLSchemes</key>
-			<array>
 				<string>autonomy-wc</string>
-				<string>wc</string>
 			</array>
 		</dict>
 	</array>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -32,32 +32,14 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLName</key>
-			<string>autonomy-deeplink</string>
+			<string>me.autonomy</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
+				<string>wc</string>
 				<string>autonomy</string>
-			</array>
-		</dict>
-		<dict>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-			<key>CFBundleURLName</key>
-			<string>autonomy-tezos</string>
-			<key>CFBundleURLSchemes</key>
-			<array>
 				<string>autonomy-tezos</string>
 				<string>tezos</string>
-			</array>
-		</dict>
-		<dict>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-			<key>CFBundleURLName</key>
-			<string>autonomy-wc</string>
-			<key>CFBundleURLSchemes</key>
-			<array>
 				<string>autonomy-wc</string>
-				<string>wc</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
**Description**

The Autonomy app doesn't seem to register the URI scheme properly. It's been always overridden by other wallet apps for the `wc` scheme.
This PR attempts to fix that by applying the same practice from the Rainbow wallet app.