### PR TITLE
Select Discovery when new feed notification

### DIFF
--- a/lib/screen/editorial/editorial_page.dart
+++ b/lib/screen/editorial/editorial_page.dart
@@ -69,7 +69,7 @@ class EditorialPageState extends State<EditorialPage>
     context.read<EditorialBloc>().add(GetEditorialEvent());
   }
 
-  void selectTap(HomePageTab tab) {
+  void selectTab(HomePageTab tab) {
     int index = widget.isShowDiscover && tab == HomePageTab.EDITORIAL ? 1 : 0;
     if (_tabController.index != index) {
       _tabController.animateTo(index);

--- a/lib/screen/editorial/editorial_page.dart
+++ b/lib/screen/editorial/editorial_page.dart
@@ -69,6 +69,13 @@ class EditorialPageState extends State<EditorialPage>
     context.read<EditorialBloc>().add(GetEditorialEvent());
   }
 
+  void selectTap(HomePageTab tab) {
+    int index = widget.isShowDiscover && tab == HomePageTab.EDITORIAL ? 1 : 0;
+    if (_tabController.index != index) {
+      _tabController.animateTo(index);
+    }
+  }
+
   void _scrollListener() {
     final controller =
         _tabController.index == 0 ? _feedController : _editorialController;

--- a/lib/screen/home/home_navigation_page.dart
+++ b/lib/screen/home/home_navigation_page.dart
@@ -523,6 +523,7 @@ class _HomeNavigationPageState extends State<HomeNavigationPage>
             route.settings.name == AppRouter.homePage ||
             route.settings.name == AppRouter.homePageNoTransition);
         memoryValues.homePageInitialTab = HomePageTab.DISCOVER;
+        _editorialPageStateKey.currentState?.selectTap(HomePageTab.DISCOVER);
         _pageController.jumpToPage(HomeNavigatorTab.DISCOVER.index);
         break;
       case "new_message":

--- a/lib/screen/home/home_navigation_page.dart
+++ b/lib/screen/home/home_navigation_page.dart
@@ -523,7 +523,7 @@ class _HomeNavigationPageState extends State<HomeNavigationPage>
             route.settings.name == AppRouter.homePage ||
             route.settings.name == AppRouter.homePageNoTransition);
         memoryValues.homePageInitialTab = HomePageTab.DISCOVER;
-        _editorialPageStateKey.currentState?.selectTap(HomePageTab.DISCOVER);
+        _editorialPageStateKey.currentState?.selectTab(HomePageTab.DISCOVER);
         _pageController.jumpToPage(HomeNavigatorTab.DISCOVER.index);
         break;
       case "new_message":


### PR DESCRIPTION
**Description**

- Story link: [Editorial instead of Discover tab selected when user clicks on a push notification about new feed#2767](https://github.com/bitmark-inc/autonomy-apps/issues/2767)
**Describe your changes**

- [ ] Added a function A to process data B
- [ ] Created new column C to store D state
- [ ] Refactor workflow E to improve performance because of F
