### PR TITLE
fix(nft_collection): call reindex when add new addresses

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1742,8 +1742,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: edfd60000c35caca00ccc71c43a7411c0c0d7acc
-      resolved-ref: edfd60000c35caca00ccc71c43a7411c0c0d7acc
+      ref: "103d9009bd87a5d95123c53dd0a0ee4da6bc3904"
+      resolved-ref: "103d9009bd87a5d95123c53dd0a0ee4da6bc3904"
       url: "https://github.com/autonomy-system/nft-collection"
     source: git
     version: "0.0.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1742,8 +1742,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: d3cc13e8c56d2c005c85f7a2b3d898162a122e51
-      resolved-ref: d3cc13e8c56d2c005c85f7a2b3d898162a122e51
+      ref: edfd60000c35caca00ccc71c43a7411c0c0d7acc
+      resolved-ref: edfd60000c35caca00ccc71c43a7411c0c0d7acc
       url: "https://github.com/autonomy-system/nft-collection"
     source: git
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -123,7 +123,7 @@ dependencies:
   nft_collection:
     git:
       url: https://github.com/autonomy-system/nft-collection
-      ref: edfd60000c35caca00ccc71c43a7411c0c0d7acc
+      ref: 103d9009bd87a5d95123c53dd0a0ee4da6bc3904
   autonomy_tv_proto:
     git:
       url: https://github.com/autonomy-system/autonomy-tv-proto-communication

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -123,7 +123,7 @@ dependencies:
   nft_collection:
     git:
       url: https://github.com/autonomy-system/nft-collection
-      ref: d3cc13e8c56d2c005c85f7a2b3d898162a122e51
+      ref: edfd60000c35caca00ccc71c43a7411c0c0d7acc
   autonomy_tv_proto:
     git:
       url: https://github.com/autonomy-system/autonomy-tv-proto-communication


### PR DESCRIPTION
**Description**

- Story link: [Sometimes, local cache of AU does not reload to get new indexing for view-only address](https://github.com/bitmark-inc/autonomy-apps/issues/3214)

**Describe your changes**

- [ ] Added a function A to process data B
- [ ] Created new column C to store D state
- [ ] Refactor workflow E to improve performance because of F
