### PR TITLE
fix(airdrop): allow claim into view_only airdrop

### DIFF
--- a/lib/service/navigation_service.dart
+++ b/lib/service/navigation_service.dart
@@ -17,7 +17,6 @@ import 'package:autonomy_flutter/screen/interactive_postcard/design_stamp.dart';
 import 'package:autonomy_flutter/screen/irl_screen/webview_irl_screen.dart';
 import 'package:autonomy_flutter/screen/send_receive_postcard/receive_postcard_page.dart';
 import 'package:autonomy_flutter/screen/settings/help_us/inapp_webview.dart';
-import 'package:autonomy_flutter/service/airdrop_service.dart';
 import 'package:autonomy_flutter/service/metric_client_service.dart';
 import 'package:autonomy_flutter/util/asset_token_ext.dart';
 import 'package:autonomy_flutter/util/constants.dart';
@@ -170,7 +169,6 @@ class NavigationService {
         claimFunction,
   }) async {
     log.info('NavigationService.openClaimTokenPage');
-    final isAllowViewOnlyClaim = AirdropType.memento6.seriesId == series.id;
     if (navigatorKey.currentState?.mounted == true &&
         navigatorKey.currentContext != null) {
       await navigatorKey.currentState?.pushNamed(
@@ -178,7 +176,7 @@ class NavigationService {
         arguments: ClaimTokenPagePayload(
           series: series,
           otp: otp,
-          allowViewOnlyClaim: isAllowViewOnlyClaim,
+          allowViewOnlyClaim: true,
           claimFunction: claimFunction,
         ),
       );


### PR DESCRIPTION
**Description**

- Story link: [FF app auto create a new full address although having 1 view-only address when user claim an airdrop](https://github.com/bitmark-inc/autonomy-apps/issues/3049)

**Describe your changes**

- [ ] Added a function A to process data B
- [ ] Created new column C to store D state
- [ ] Refactor workflow E to improve performance because of F
